### PR TITLE
Add inline order submission scripts for Apps Script API

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PIZZ’AMIGO — Montmerle-sur-Saône</title>
   <link rel="stylesheet" href="styles.css">
+  <script>
+    window.APP = {
+      API_URL: "https://script.google.com/macros/s/AKfycbw_cAhR_LZgNRPzyABxZIWgqaYf-mBTPoisV8QgFgYUE-lVgI5pY-9_RFk_Z0w28itu/exec",
+      ADMIN_KEY: ""
+    };
+  </script>
 </head>
 <body>
   <div class="ribbon"></div>
@@ -65,5 +71,163 @@
   <footer class="footer">© PIZZ’AMIGO — Montmerle-sur-Saône</footer>
 
   <script type="module" src="app.js"></script>
+  <script>
+  (function(){
+    function parseCartFromUI(){
+      const container = document.querySelector('#ckItems');
+      const items = [];
+      if(!container) return { items };
+      const html = container.innerHTML || '';
+      const rows = html.split(/<br\s*\/?>/i).map(row => row.replace(/<[^>]+>/g, '').trim()).filter(Boolean);
+      rows.forEach(row => {
+        const cleaned = row.replace(/^•\s*/, '').trim();
+        if(!cleaned) return;
+        const parts = cleaned.split('—').map(part => part.trim());
+        if(parts.length < 2) return;
+        const left = parts[0];
+        const right = parts.slice(1).join(' — ');
+        const qtyMatch = left.match(/×\s*(\d+)/i);
+        const qty = qtyMatch ? Number(qtyMatch[1]) || 1 : 1;
+        const name = left.split('×')[0].trim();
+        const totalPrice = (() => {
+          const normalized = right.replace(/[^0-9,.-]/g, '').replace(',', '.');
+          const value = Number.parseFloat(normalized);
+          return Number.isFinite(value) ? value : 0;
+        })();
+        const price = qty > 0 ? Number((totalPrice / qty).toFixed(2)) : 0;
+        if(!name) return;
+        items.push({ name, qty, price });
+      });
+      return { items };
+    }
+
+    function getCart(){
+      try{
+        const stored = JSON.parse(localStorage.getItem('cart') || '{}');
+        if(stored && Array.isArray(stored.items) && stored.items.length){
+          return stored;
+        }
+      }catch(err){ /* ignore */ }
+      return parseCartFromUI();
+    }
+
+    function setCart(value){
+      try{
+        localStorage.setItem('cart', JSON.stringify(value || {}));
+      }catch(err){ /* ignore */ }
+    }
+
+    async function sendOrder(){
+      const API_URL = window.APP?.API_URL;
+      const ADMIN_KEY = window.APP?.ADMIN_KEY || '';
+      if(!API_URL){
+        alert('API non configurée.');
+        return { ok:false, error:'no_api' };
+      }
+
+      const $ = selector => document.querySelector(selector);
+      const name = ($('#ck-name') || $('#ckName'))?.value?.trim() || '';
+      const phone = ($('#ck-phone') || $('#ckPhone'))?.value?.trim() || '';
+      const slot = ($('#ck-slot') || $('#ckSlot'))?.value?.trim() || '';
+      const note = ($('#ck-note') || $('#ckNote'))?.value?.trim() || '';
+
+      const cart = getCart();
+      const items = Array.isArray(cart.items) ? cart.items : [];
+      const total = Number(items.reduce((sum, item) => {
+        const price = Number(item.price) || 0;
+        const qty = Number(item.qty) || 0;
+        return sum + price * qty;
+      }, 0).toFixed(2));
+
+      if(!name || !phone || !slot || items.length === 0){
+        alert('Merci de compléter nom, téléphone, horaire et panier.');
+        return { ok:false, error:'invalid_form' };
+      }
+
+      const payload = {
+        name,
+        phone,
+        slot,
+        note,
+        items: items.map(item => ({
+          name: item.name,
+          qty: Number(item.qty) || 1,
+          price: Number(item.price) || 0
+        })),
+        total,
+        source: 'site'
+      };
+
+      const url = API_URL + (ADMIN_KEY ? `?key=${encodeURIComponent(ADMIN_KEY)}` : '');
+      const DEV = /[?&]dev=1/.test(location.search);
+
+      try{
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+
+        const raw = await response.text();
+        let data;
+        try{
+          data = JSON.parse(raw);
+        }catch(err){
+          data = { ok:false, error:'bad_json', raw };
+        }
+
+        if(DEV) console.log('API status', response.status, data);
+
+        if(!response.ok || !data || data.ok !== true){
+          const msg = (data && (data.error || data.message)) || `HTTP ${response.status}`;
+          alert("Impossible d'envoyer la commande. Merci de réessayer." + (DEV ? `\n[${msg}]` : ''));
+          return { ok:false, error: msg };
+        }
+
+        setCart({ items: [] });
+        document.querySelector('#checkout')?.close();
+        alert('Commande enregistrée. Merci !');
+        setTimeout(() => { try{ location.reload(); }catch(err){ /* ignore */ } }, 0);
+        return { ok:true };
+      }catch(error){
+        if(DEV) console.error(error);
+        alert("Impossible d'envoyer la commande. Merci de réessayer.");
+        return { ok:false, error: error?.message || 'network_error' };
+      }
+    }
+
+    const handler = event => {
+      const target = event.target instanceof Element ? event.target.closest('#btn-send, #ck-send, .btn-send, #btnSend') : null;
+      if(!target) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      sendOrder();
+    };
+
+    document.addEventListener('click', handler, true);
+    window.sendOrder = sendOrder;
+  })();
+  </script>
+  <script>
+  (function(){
+    if(!/[?&]dev=1/.test(location.search)) return;
+    const button = document.createElement('button');
+    button.textContent = 'Test API';
+    button.style.cssText = 'position:fixed;top:10px;right:10px;z-index:9999;padding:6px 10px;border-radius:8px;border:1px solid #444;background:#222;color:#fff';
+    button.onclick = () => {
+      const cart = { items:[{ name:'TEST Pizza', qty:1, price:9.5 }] };
+      try{ localStorage.setItem('cart', JSON.stringify(cart)); }catch(err){ /* ignore */ }
+      const nameInput = document.querySelector('#ck-name, #ckName');
+      const phoneInput = document.querySelector('#ck-phone, #ckPhone');
+      const slotInput = document.querySelector('#ck-slot, #ckSlot');
+      if(nameInput) nameInput.value = 'Test';
+      if(phoneInput) phoneInput.value = '0600000000';
+      if(slotInput) slotInput.value = '19:00';
+      if(window.sendOrder) window.sendOrder(); else alert('sendOrder indisponible');
+    };
+    document.body.appendChild(button);
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the global Apps Script configuration block to index.html
- implement the inline checkout submission logic that builds the payload from the modal and posts it to the Apps Script API
- add a dev-only helper button to trigger a test order against the API

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d66f90fa108329bdcfe2498c9f755e